### PR TITLE
Добавить CD (#7)

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to QA stand
+run-name: Deploy commit "${{ github.sha }}"
+
+on:
+  push:
+    tags:
+      - deployed/qa
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Run deploy script via ssh
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.QA_STAND_SSH_HOST }}
+          username: ${{ secrets.QA_STAND_SSH_USERNAME }}
+          password: ${{ secrets.QA_STAND_SSH_PASSWORD }}
+          script: |
+            cd /wlss-bff
+            docker compose -f envs/qa/deploy/docker-compose.yml down
+
+            # fetch tag even if it was force pushed and checkout
+            git fetch origin +refs/tags/deployed/qa:refs/tags/deployed/qa
+            git checkout deployed/qa
+
+            docker compose -f envs/qa/deploy/docker-compose.yml up --build --detach

--- a/README.md
+++ b/README.md
@@ -109,3 +109,21 @@ pytest --cov=src ; coverage html
 ```bash
 pytest --cov=src --cov-context=test ; coverage html --show-contexts --no-skip-covered
 ```
+
+
+## [Deploy](#table-of-contents)
+
+_Only users with write access are able to deploy._
+
+1. Fetch the last version of the `deployed/qa` tag:
+```bash
+git fetch origin +refs/tags/deployed/qa:refs/tags/deployed/qa
+```
+
+2. Checkout to branch/commit you want to deploy.
+
+3. Create and push new version of the `deployed/qa` tag:
+```bash
+git tag --annotate --force deployed/qa --message ''
+git push origin deployed/qa --force
+```

--- a/envs/qa/deploy/Dockerfile
+++ b/envs/qa/deploy/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /wlss-bff
+
+RUN apt-get update \
+    && pip install --upgrade pip \
+    && pip install poetry==1.4.2
+
+RUN poetry config virtualenvs.create false
+
+COPY poetry.lock pyproject.toml ./
+
+RUN poetry install --with=app,deploy
+
+COPY . ./

--- a/envs/qa/deploy/Dockerfile.dockerignore
+++ b/envs/qa/deploy/Dockerfile.dockerignore
@@ -1,0 +1,17 @@
+# This .dockerignore file works for build context of a Dockerfile placed in the same directory.
+
+# All paths in this file is relative to the build content provided in associated docker-compose.yml.
+# See "build:context" section.
+
+# Please keep this list in alphabetical order.
+
+__pycache__
+
+.mypy_cache
+
+.pytest_cache
+
+.ruff_cache
+
+# prevent production environment variables to be in the image pushed to some public docker repository
+envs/qa/deploy/.env

--- a/envs/qa/deploy/docker-compose.yml
+++ b/envs/qa/deploy/docker-compose.yml
@@ -1,0 +1,24 @@
+name: wlss-bff-qa
+
+services:
+  app:
+    build:
+      context: ../../..  # path from the corrent file to the project root dir
+      dockerfile: envs/qa/deploy/Dockerfile  # path from the project root dir to the Dockerfile
+    environment:
+      - WLSS_ENV=qa/deploy
+    volumes:
+      - .env:/wlss-bff/envs/qa/deploy/.env
+    entrypoint: >
+      bash -c "
+        gunicorn --config=envs/qa/deploy/gunicorn/config.py
+      "
+
+  nginx:
+    image: nginx:1.23.3-alpine
+    ports:
+      - 8000:8000
+    depends_on:
+      - app
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro

--- a/envs/qa/deploy/env.sh
+++ b/envs/qa/deploy/env.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ENV_FILE=$SCRIPT_DIR/.env
+
+# ======================================================================================================================
+
+# The environment vairables below will be written
+# to the .env file in the directory along with this script.
+
+# Please keep environment variables in the current script
+# alphabetically sorted and use double quotes around the values.
+
+# You can read more why we need to use quotes here:
+# https://stackoverflow.com/a/71538763/8431075
+
+cat > $ENV_FILE << EOF
+BFF_URL=""  # put actual url to BFF instance, like "http://185.154.195.26:8000"
+EOF
+
+# ======================================================================================================================
+
+cat << EOF
+
+Default environment variables has been written to:
+$ENV_FILE
+
+Please adjust variables in this file.
+
+EOF

--- a/envs/qa/deploy/gunicorn/config.py
+++ b/envs/qa/deploy/gunicorn/config.py
@@ -1,0 +1,13 @@
+accesslog = "-"  # here "-" means stdout
+
+# gunicorn listens all connections but it's still secure
+# since it's run in isolated docker network and only rev-proxy has access to it
+bind = "0.0.0.0:8000"
+
+errorlog = "-"  # here "-" means stdout
+
+worker_class = "uvicorn.workers.UvicornWorker"
+
+workers = 4
+
+wsgi_app = "src.app:app"

--- a/envs/qa/deploy/nginx/nginx.conf
+++ b/envs/qa/deploy/nginx/nginx.conf
@@ -1,0 +1,13 @@
+events {}
+
+http {
+
+    server {
+        listen 8000;
+        server_name _;
+
+        location / {
+            proxy_pass http://app:8000;
+        }
+    }
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -253,6 +253,27 @@ files = [
 flake8 = ">3.0.0"
 
 [[package]]
+name = "gunicorn"
+version = "20.1.0"
+description = "WSGI HTTP Server for UNIX"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
+    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
+]
+
+[package.dependencies]
+setuptools = ">=3.0"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -1015,6 +1036,23 @@ files = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "69.1.1"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-69.1.1-py3-none-any.whl", hash = "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56"},
+    {file = "setuptools-69.1.1.tar.gz", hash = "sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1424,4 +1462,4 @@ resolved_reference = "e2c11e344d096579e2582c45fb08007195ebcc8d"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "7a7f056da225a72bb08f5003f5f96af3f8b37952e7843869cc1ab310a2ff9cef"
+content-hash = "201f5a035f5de00406884e06112f973b88a5680a4185f9fdbd18dda7ab890771"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,14 @@ pytest-cov = "4.1.0"
 pytest-spec = "3.2.0"
 
 
+[tool.poetry.group.deploy]
+optional = true
+
+
+[tool.poetry.group.deploy.dependencies]
+gunicorn = "20.1.0"
+
+
 [build-system]
 
 requires = ["poetry-core"]


### PR DESCRIPTION
Мы хотим автоматизировать процесс доставки новых изменений на сервер. Для этого было принято решение настроить простой Continuous Delivery пайплайн.

В будущем мы планируем иметь два стенда - для тестирования (qa) и для конечных пользователей (prod). И так как проект сейчас находится в стадии разработки, то для нас более актуален тестовый стенд, поэтому в рамках этой задачи мы будем настраивать деплой на тестовый стенд.

Далее будет общее описание изменений, которые нужно будет сделать в репозитории:

- Добавить uvicorn (если ещё не добавлен)
- Добавить gunicorn и прописать конфиг к нему
- Добавить `Dockerfile`, `docker-compose.yml` и `env.sh` для тестового стенда
- В папку рядом с докерфайлом добавить `Dockerfile.dockerignore` в котором исключить секреты и лишние папки кэша вспомогательных тулов (типо линтеров и пайтеста)
- Добавить nginx в докер компоуз и конфиг к нему
- Добавить гитхаб воркфлоу, которое будет разворачивать докер-компоуз на vps через ssh при пуше тега test
- убедиться, что приложение будет слушать 80-й порт, т.к. на 80-ом порте будет сервер, который раздаёт фронт

Далее приведены шаги, которые помогут настроить vps. Конечно, эти шаги могут отличаться в зависимости от конкретной vps, но их описание здесь может дать общее представление о том, что нужно сделать при разворачивании проекта на vps.

- Установить на VPS последнюю версию Docker Desktop по гайду из офф [доки](https://docs.docker.com/desktop/install/ubuntu/#install-docker-desktop)

  Чтобы скопировать установщик докера на vps нужно использовать что-то такое: ```bash scp ./docker-desktop-4.19.0-amd64.deb root@185.154.195.26:/downloads/docker-desktop-4.19.0-amd64.deb ```

- Проверить что docker работает ```bash docker container ls ```

  Если эта команда выше даёт ошибку связанную с сокетом докера, то [этот](https://stackoverflow.com/questions/43569781/unable-to-start-docker-service-with-error-failed-to-start-docker-service-unit/43576628#43576628) ответ на стэке может помочь. Там рекомендуют установить какой-то RHEL плагин такой командой: ```bash curl -sSL https://get.docker.com/ | sh ```

- Так как нам нужна возможность получать последние изменения проекта из гита на нашем vps сервере, то на туда необходимо установить гит (см офф [доку](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git))

Так как у гит-клиента установленного на vps должен быть доступ к нашему репозиторию, то необходимо настроить ssh ключи для соединения с гитхабом.

- Сгенерировать ssh ключ на VPS машине (см офф [доку](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) гитхаба) и добавить его в свой (личный) гитхаб аккаунт.

- Склонировать репозиторий на VPS машину в папку /wlss-bff: ``` git clone git@github.com:week-password/wisher-bff.git /wlss-bff ```

- перейти в папку с проектом `cd /wlss-bff` и настроить юзера для проекта (см офф [доку](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup#_your_identity) гита)

- Так как на vps машине будет полноценный гит репозиторий, мы хотим обезопасить себя от случайных коммитов с vps машины. Для этого необходимо запретить коммиты в репозиторий с помощью гит хука: ```bash echo "echo 'This repository is read-only'; exit 1;" > .git/hooks/pre-commit ```

Т.к. мы хотим, чтобы на стенд разворачивалась только та версия, которая нам нужна, а не любой коммит запушшеный в девелоп, было принято решение триггерить деплой на пуш определенного гит-тэга. Этот тэг будет виден всем разработчикам в гите, и они будут понимать какая именно версия и на какой стенд задеплоена в данный момент.

- С локальной машины создать тэг для тестового стенда и запушить его на ремоут: ```bash git push origin test --force ```

- На vps машине зафетчить этот тэг с ремоута и зачекаутится на него: ```bash git fetch origin +refs/tags/deploy/qa:refs/tags/deploy/qa git checkout test ```

- Перед тем как пытаться запустить наше приложение на vps, необходимо остановить apache сервер, который по дефолту может стоять на vps и слушать 80-й порт:
```bash
/etc/init.d/apache2 stop
```
  другие варианты этой команды можно посмотреть по [ссылке](https://www.cyberciti.biz/faq/star-stop-restart-apache2-webserver/)

- После этого необходимо убедится, что порт действительно освободился. Для этого надо из браузера зайти на айпи нашего сервера. Если при этом вы всё ещё видите стартовую страницу apache, то надо удалить `index.html` где-то внутри `/var/www`.

- Далее необходимо настроить окружение, в котором будет запускаться наше приложение. Для этого нужно сгенерировать `.env` файл ```bash source envs/qa/deploy/env.sh ``` и выставить корректные значения для секретов.

Процесс деплоя приложения будет управляться из воркфлоу гитхаба. Мы планируем в воркфлоу гитхаба вызывать команды типа `docker compose ... up/down` на нашем удалённом vps через ssh. Для этого нам понадобится [экшн](https://github.com/appleboy/ssh-action), который позволяет выполнять ssh команды из гитхаба.

- Чтобы этот экшн смог подсоединиться к нашему vps серверу по ssh, необходимо добавить в секреты репозитория на гитхабе креды для соединения с vps по ssh ([хост, юзер и пароль). Мы будем передавать эти секреты в ssh экшн через `${{ secrets.<SECRET_NAME> }}`

После этого можно пробовать запускать деплой с помощью пуша тэга `deploy/qa`.

PS. Также мы решили пока не добавлять удаление ранов деплоя в cleanup-воркфлоу, потому что не совсем понятно, должны ли мы удалять раны для несуществующих коммитов, а если должны, то как. Ведь в случае удалении ветки, на которой стоит тэг, коммиты всё равно останутся под тэгом. А когда тэг будет переключен на другую ветку мы не сможем найти предыдущие раны с удалённой ветки, т.к. нам придётся проверить все раны тэга, а их со временем может накопиться очень много. К тому же нам придётся сверять эти раны с хэшами коммитов в репозитории, чтобы понять существует ли такой коммит. И в таком случае нам надо будет взять абсолютно все коммиты репозитория, ведь тэг не привязан ни к какой ветке и может быть в любой из них.