### PR TITLE
Добавить .env в .gitignore (#9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .coverage
+.env


### PR DESCRIPTION
В рамках этой задачи необходимо добавить .env файлы в .gitignore, чтобы предотвратить их случайное попадание в репозиторий (т.к. в этих файлах могут содержаться чувствительные данные, особенно для стендов деплоя).