### PR TITLE
Добавить эндпойнт на получение одного аккаунта (#19)

### DIFF
--- a/src/account/controllers.py
+++ b/src/account/controllers.py
@@ -9,8 +9,10 @@ from wlss.shared.types import Id
 
 from src.account.dtos import (
     CreateAccountResponse,
+    GetAccountByLoginResponse,
     GetAccountsResponse,
 )
+from src.account.exceptions import AccountNotFoundError
 from src.config import CONFIG
 
 
@@ -25,6 +27,18 @@ async def create_account(request_data: CreateAccountRequest) -> CreateAccountRes
     async with Api(base_url=CONFIG.BFF_URL) as api:
         response = await api.account.create_account(api_request_data)
     return CreateAccountResponse.from_(response)
+
+
+async def get_account_by_login(
+    account_login: AccountLogin,
+    authorization: HTTPAuthorizationCredentials,
+) -> GetAccountByLoginResponse:
+    async with Api(base_url=CONFIG.BFF_URL) as api:
+        response = await api.account.get_accounts(account_logins=[account_login], token=authorization.credentials)
+    if not response.accounts:
+        raise AccountNotFoundError()
+    assert len(response.accounts) == 1
+    return GetAccountByLoginResponse.from_(response.accounts[0])
 
 
 async def get_accounts(

--- a/src/account/dtos.py
+++ b/src/account/dtos.py
@@ -37,6 +37,11 @@ class CreateAccountResponse(Schema):
         name: ProfileNameField = Field(..., example="John Doe")
 
 
+class GetAccountByLoginResponse(Schema):
+    id: IdField = Field(..., example=42)
+    login: AccountLoginField = Field(..., example="john_doe")
+
+
 class GetAccountsResponse(RootModel):  # type: ignore[type-arg]
     root: list[_Account]
     class _Account(Schema):  # noqa: E301

--- a/src/account/exceptions.py
+++ b/src/account/exceptions.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from fastapi import status
+
+from src.shared.exceptions import NotFoundException
+
+
+class AccountNotFoundError(NotFoundException):
+    resource: str = "Account"
+
+    description = "Requested resource not found."
+    details = "Requested resource doesn't exist or has been deleted."
+    status_code = status.HTTP_404_NOT_FOUND

--- a/src/account/routes.py
+++ b/src/account/routes.py
@@ -5,11 +5,13 @@ from typing import Annotated
 from api.account.fields import AccountLoginField
 from api.shared.fields import IdField
 from fastapi import APIRouter, Body, Query, status
+from fastapi.params import Path
 
 from src.account import controllers
 from src.account.dtos import (
     CreateAccountRequest,
     CreateAccountResponse,
+    GetAccountByLoginResponse,
     GetAccountsResponse,
     MatchAccountEmailRequest,
     MatchAccountLoginRequest,
@@ -35,6 +37,24 @@ async def create_account(
     request_data: Annotated[CreateAccountRequest, Body()],
 ) -> CreateAccountResponse:
     return await controllers.create_account(request_data)
+
+
+@router.get(
+    "/accounts/logins/{account_login}",
+    description="Get account. Account info is available for every logged in user.",
+    responses={
+        status.HTTP_200_OK: {"description": "Account info returned"},
+        status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
+        status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
+    },
+    status_code=status.HTTP_200_OK,
+    summary="Get account.",
+)
+async def get_account_by_login(
+    authorization: Authorization,
+    account_login: Annotated[AccountLoginField, Path(example="john_doe")],
+) -> GetAccountByLoginResponse:
+    return await controllers.get_account_by_login(account_login, authorization)
 
 
 @router.get(

--- a/src/app.py
+++ b/src/app.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 import src.routes
-from src.shared.exceptions import TooLargeException
+from src.shared.exceptions import NotFoundException, TooLargeException
 
 
 if TYPE_CHECKING:
@@ -63,6 +63,18 @@ def handle_http_error(_: Request, exception: httpx.HTTPStatusError) -> JSONRespo
     return JSONResponse(
         status_code=exception.response.status_code,
         content=exception.response.json(),
+    )
+
+
+@app.exception_handler(NotFoundException)
+async def handle_not_found(_: Request, exception: NotFoundException) -> JSONResponse:
+    return JSONResponse(
+        status_code=exception.status_code,
+        content={
+            "resource": exception.resource,
+            "description": exception.description,
+            "details": exception.details,
+        },
     )
 
 

--- a/tests/test_account/conftest.py
+++ b/tests/test_account/conftest.py
@@ -43,6 +43,32 @@ def create_account_response():
 
 
 @pytest.fixture
+def get_account_by_login_request():
+    return Predicate(
+        method="GET",
+        path="/accounts",
+        query={"account_login": "john_doe"},
+        headers={"Authorization": "Bearer token"},
+    )
+
+
+@pytest.fixture
+def get_account_by_login_response():
+    response_body = {
+        "accounts": [
+            {"id": 1, "login": "john_doe"},
+        ],
+    }
+    return Response(body=response_body, status_code=200, headers={"content-type": "application/json"})
+
+
+@pytest.fixture
+def get_account_by_login_response_with_nonexistent_account():
+    response_body = {"accounts": []}
+    return Response(body=response_body, status_code=200, headers={"content-type": "application/json"})
+
+
+@pytest.fixture
 def get_accounts_request_for_two_accounts():
     return Predicate(
         method="GET",

--- a/tests/test_account/test_get_account_by_login.py
+++ b/tests/test_account/test_get_account_by_login.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.anyio
+@pytest.mark.fixtures({"client": "client", "api": "api_configured_with_api_stubs"})
+@pytest.mark.api_stubs(["get_account_by_login_request", "get_account_by_login_response"])
+async def test_get_account_by_login_returns_200_with_correct_response(f):
+    result = await f.client.get("/accounts/logins/john_doe", headers={"Authorization": "Bearer token"})
+
+    assert result.status_code == 200
+    assert result.json() == {"id": 1, "login": "john_doe"}
+
+
+@pytest.mark.anyio
+@pytest.mark.fixtures({"client": "client", "api": "api_configured_with_api_stubs"})
+@pytest.mark.api_stubs(["get_account_by_login_request", "get_account_by_login_response_with_nonexistent_account"])
+async def test_get_account_by_login_with_nonexistent_account_returns_404_with_correct_response(f):
+    result = await f.client.get("/accounts/logins/john_doe", headers={"Authorization": "Bearer token"})
+
+    assert result.status_code == 404
+    assert result.json() == {
+        "resource": "Account",
+        "description": "Requested resource not found.",
+        "details": "Requested resource doesn't exist or has been deleted.",
+    }


### PR DESCRIPTION
Мы уже добавляли эндпойнт, который получает аккаунты для списка айдишников, но поскольку фронт не планирует работать со списком айдишников, и планирует использовать этот эндпойнт для получения информации только одному аккаунту.

В рамках этой задачи необходимо добавить эндпойнт `get_account`.