### PR TITLE
Поправить работу с файлами согласно требованиям фронта (#26)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -51,8 +51,8 @@ wlss = {git = "https://github.com/week-password/wlss-backend-lib.git", rev = "e2
 [package.source]
 type = "git"
 url = "https://github.com/week-password/wlss-backend.git"
-reference = "982cdadae5fb68c2567ba5171b91002f08f25eaa"
-resolved_reference = "982cdadae5fb68c2567ba5171b91002f08f25eaa"
+reference = "f722f39af91b39cebc433b3419c0211d9555d8e9"
+resolved_reference = "f722f39af91b39cebc433b3419c0211d9555d8e9"
 
 [[package]]
 name = "beautifulsoup4"
@@ -1928,4 +1928,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "7776e7011bffe0487c9516857859fe3c7fa7c7897b26559eb60b52aa30e0d4f3"
+content-hash = "e78d036ff804da4b4062cf8076251601d2f7bb88bdf2b4347f4adf9e159acd7f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = "~3.11"
 optional = true
 
 [tool.poetry.group.app.dependencies]
-api = {git = "https://github.com/week-password/wlss-backend.git", rev = "982cdadae5fb68c2567ba5171b91002f08f25eaa"}
+api = {git = "https://github.com/week-password/wlss-backend.git", rev = "f722f39af91b39cebc433b3419c0211d9555d8e9"}
 fastapi = {extras = ["all"], version = "0.109.0" }  # we need "all" at least for uvicorn
 pydantic = "2.5.3"
 pyjwt = "2.8.0"

--- a/src/file/constants.py
+++ b/src/file/constants.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 
 BYTE = 1
-KILOBYTE = 1000 * BYTE
-MEGABYTE = 1000 * KILOBYTE
+KILOBYTE = 1024 * BYTE
+MEGABYTE = 1024 * KILOBYTE
 
 MAX_SIZE = 10 * MEGABYTE
 

--- a/src/file/controllers.py
+++ b/src/file/controllers.py
@@ -28,10 +28,10 @@ async def create_file(
     return CreateFileResponse.from_(response)
 
 
-async def get_file(file_id: UuidField, authorization: HTTPAuthorizationCredentials, tmp_dir: Path) -> GetFileResponse:
+async def get_file(file_id: UuidField, tmp_dir: Path) -> GetFileResponse:
     tmp_file_path = tmp_dir / str(file_id)
     async with Api(base_url=CONFIG.BACKEND_API_URL) as api:
-        response = await api.file.get_file(file_id, authorization.credentials, tmp_file_path)
+        response = await api.file.get_file(file_id, tmp_file_path)
     return GetFileResponse(
         path=response.path,
         status_code=response.status_code,

--- a/src/file/routes.py
+++ b/src/file/routes.py
@@ -50,7 +50,6 @@ async def create_file(
 async def get_file(
     background_tasks: BackgroundTasks,  # noqa: ARG001
     file_id: Annotated[UuidField, Path(example="47b3d7a9-d7d3-459a-aac1-155997775a0e")],
-    authorization: Authorization,
     tmp_dir: Annotated[pathlib.Path, Depends(get_tmp_dir)],
 ) -> GetFileResponse:
-    return await controllers.get_file(file_id, authorization, tmp_dir)
+    return await controllers.get_file(file_id, tmp_dir)

--- a/tests/test_file/conftest.py
+++ b/tests/test_file/conftest.py
@@ -27,11 +27,7 @@ def create_file_response():
 
 @pytest.fixture
 def get_file_request():
-    return Predicate(
-        method="GET",
-        path="/files/d3bb68db-052f-4851-b74d-d9c884fd43df",
-        headers={"Authorization": "Bearer token"},
-    )
+    return Predicate(method="GET", path="/files/d3bb68db-052f-4851-b74d-d9c884fd43df")
 
 
 @pytest.fixture

--- a/tests/test_file/test_create_file.py
+++ b/tests/test_file/test_create_file.py
@@ -12,7 +12,7 @@ async def test_create_file_returns_201_with_correct_response(f):
     result = await f.client.post(
         "/files",
         headers={"Authorization": "Bearer token"},
-        files={"upload_file": ("image.png", b"image binary data", "image/png")},
+        files={"file": ("image.png", b"image binary data", "image/png")},
     )
 
     assert result.status_code == 201
@@ -32,7 +32,7 @@ async def test_create_file_with_too_large_file_returns_413_with_correct_response
     result = await f.client.post(
         "/files",
         headers={"Authorization": "Bearer token"},
-        files={"upload_file": ("image.png", large_image_data, "image/png")},
+        files={"file": ("image.png", large_image_data, "image/png")},
     )
 
     assert result.status_code == 413
@@ -49,7 +49,7 @@ async def test_create_file_with_filename_without_extension_returns_422_with_corr
     result = await f.client.post(
         "/files",
         headers={"Authorization": "Bearer token"},
-        files={"upload_file": ("image", b"image binary data", "image/png")},
+        files={"file": ("image", b"image binary data", "image/png")},
     )
 
     assert result.status_code == 422

--- a/tests/test_file/test_get_file.py
+++ b/tests/test_file/test_get_file.py
@@ -7,10 +7,7 @@ import pytest
 @pytest.mark.fixtures({"client": "client", "api": "api_configured_with_api_stubs"})
 @pytest.mark.api_stubs(["get_file_request", "get_file_response"])
 async def test_get_file_returns_200_with_correct_response(f):
-    result = await f.client.get(
-        "/files/d3bb68db-052f-4851-b74d-d9c884fd43df",
-        headers={"Authorization": "Bearer token"},
-    )
+    result = await f.client.get("/files/d3bb68db-052f-4851-b74d-d9c884fd43df")
 
     assert result.status_code == 200
     assert result.content == b"image binary data"


### PR DESCRIPTION
По запросу фронта в рамках этой задачи необходимо:
1. Изменить кратность размера файла со степени 10, на степень. Т.к. файлы с ровным количеством байт - 10_000_000 во многих системах отображаются как файлы с размером < 10Mb.
2. Переименовать поле запроса `upload_file` -> `file`.
3. Убрать access токен из эндпойнта на получение файла, т.к. фронт не может его присылать (фронт просто шлёт get запрос из браузера и не может прокидывать туда Authorization хэдер)