### PR TITLE
Поправить refresh-токен в сваггере (#32)

### DIFF
--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -15,3 +15,14 @@ Authorization = Annotated[
         ),
     ),
 ]
+
+
+AuthorizationRefresh = Annotated[
+    HTTPAuthorizationCredentials,
+    Depends(
+        HTTPBearer(
+            scheme_name="Refresh token",
+            description="Long-living token needed to refresh expired tokens.",
+        ),
+    ),
+]

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -6,7 +6,7 @@ from api.shared.fields import IdField, UuidField
 from fastapi import APIRouter, Body, Path, status
 
 from src.auth import controllers
-from src.auth.dependencies import Authorization
+from src.auth.dependencies import Authorization, AuthorizationRefresh
 from src.auth.dtos import CreateSessionRequest, CreateSessionResponse, RefreshTokensResponse
 from src.shared import swagger as shared_swagger
 
@@ -46,7 +46,7 @@ async def create_session(
 async def refresh_tokens(
     account_id: Annotated[IdField, Path(example=42)],
     session_id: Annotated[UuidField, Path(example="b9dd3a32-aee8-4a6b-a519-def9ca30c9ec")],
-    authorization: Authorization,
+    authorization: AuthorizationRefresh,
 ) -> RefreshTokensResponse:
     return await controllers.refresh_tokens(account_id, session_id, authorization)
 


### PR DESCRIPTION
В рамках этой задачи необходимо изменить описание токена в сваггере для эндпойнта обновления токенов. Вместо "Access token" этот эндпойнт должен принимать "Refresh token".